### PR TITLE
Fix the parse error on PHP 7.4

### DIFF
--- a/src/VCR/Util/StreamProcessor.php
+++ b/src/VCR/Util/StreamProcessor.php
@@ -262,13 +262,17 @@ class StreamProcessor
     /**
      * Retrieve information about a file resource.
      *
+     * Do not return the stat since we don't know the resulting the size that the file will have
+     * after having all transformations applied. When including files, PHP 7.4 and newer are sensitive
+     * to file size reported by stat.
+     *
      * @link http://www.php.net/manual/en/streamwrapper.stream-stat.php
      *
      * @return array See stat().
      */
     public function stream_stat()
     {
-        return fstat($this->resource);
+        return array();
     }
 
     /**


### PR DESCRIPTION
Do not return the stat since we don't know the resulting the size that the file will have after having all transformations applied. When including files, PHP 7.4 and newer are sensitive to file size reported by stat.

