### PR TITLE
Add makefile as an alternative to composer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+test:
+	./vendor/bin/phpunit
+
+lint:
+	./vendor/bin/php-cs-fixer fix --verbose --diff --dry-run --config-file=.php_cs
+
+fix:
+	./vendor/bin/php-cs-fixer fix --verbose --diff --config-file=.php_cs
+
+phpstan:
+	phpstan analyse src -c phpstan.neon --level=7 --no-progress -vvv


### PR DESCRIPTION
Introduced makefile integration in order to run commands like `make test` 